### PR TITLE
Fix handling allow-null attributes when scanning

### DIFF
--- a/scanner.zig
+++ b/scanner.zig
@@ -309,9 +309,15 @@ const Message = struct {
                     },
                     .object, .new_id => |new_iface| {
                         if (arg.kind == .object or target == .server) {
-                            try writer.writeAll(".{ .o = @ptrCast(*common.Object, ");
-                            try printIdentifier(writer, arg.name);
-                            try writer.writeAll(") },");
+                            if (arg.allow_null) {
+                                try writer.writeAll(".{ .o = if (");
+                                try printIdentifier(writer, arg.name);
+                                try writer.writeAll(") |o| @ptrCast(*common.Object, o) else null },");
+                            } else {
+                                try writer.writeAll(".{ .o = @ptrCast(*common.Object, ");
+                                try printIdentifier(writer, arg.name);
+                                try writer.writeAll(") },");
+                            }
                         } else {
                             if (new_iface == null) {
                                 try writer.writeAll(


### PR DESCRIPTION
The current code compares "allow_null" (with underscore) against
"allow-null" (with hyphen) from the XML. That always fails and
allow_null is left to the default value.

---

Thanks for this project! I'm getting started with zig right now, so my fix is probably not the way to go, but you get the idea. Added a test that succeeds with my change, however on master a unrelated test always fails [here](https://github.com/ifreund/zig-wayland/blob/master/scanner.zig#L751).