### PR TITLE
Use enum attributes in request arguments

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,3 +1,4 @@
+const mem = @import("std").mem;
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
@@ -38,29 +39,21 @@ pub fn build(b: *Builder) void {
     }
 
     if (examples) {
-        const globals = b.addExecutable("globals", "example/globals.zig");
-        globals.setTarget(target);
-        globals.setBuildMode(mode);
+        const example_names = [_][]const u8{ "globals", "listener", "seats" };
+        for (example_names) |example| {
+            const path = mem.concat(b.allocator, u8, &[_][]const u8{ "example/", example, ".zig" }) catch unreachable;
+            const exe = b.addExecutable(example, path);
+            exe.setTarget(target);
+            exe.setBuildMode(mode);
 
-        globals.linkLibC();
-        globals.linkSystemLibrary("wayland-client");
+            exe.linkLibC();
+            exe.linkSystemLibrary("wayland-client");
 
-        // Requires the scanner to have been run for this to build
-        // TODO: integrate scanner with build system
-        globals.addPackagePath("wayland", "wayland.zig");
+            // Requires the scanner to have been run for this to build
+            // TODO: integrate scanner with build system
+            exe.addPackagePath("wayland", "wayland.zig");
 
-        globals.install();
-    }
-
-    if (examples) {
-        const listener = b.addExecutable("listener", "example/listener.zig");
-        listener.setTarget(target);
-        listener.setBuildMode(mode);
-
-        // Requires the scanner to have been run for this to build
-        // TODO: integrate scanner with build system
-        listener.addPackagePath("wayland", "wayland.zig");
-
-        listener.install();
+            exe.install();
+        }
     }
 }

--- a/example/seats.zig
+++ b/example/seats.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const wayland = @import("wayland");
+const wl = wayland.client.wl;
+
+pub fn main() !void {
+    const display = try wl.Display.connect(null);
+    const registry = try display.getRegistry();
+    var running: bool = true;
+    try registry.setListener(*bool, listener, &running);
+    while (running) {
+        _ = try display.dispatch();
+    }
+}
+
+fn listener(registry: *wl.Registry, event: wl.Registry.Event, running: *bool) void {
+    switch (event) {
+        .global => |global| {
+            if (std.cstr.cmp(global.interface, wl.Seat.interface().name) == 0) {
+                const seat = registry.bind(global.name, wl.Seat, 1) catch return;
+                seat.setListener(*bool, seatListener, running) catch return;
+            }
+        },
+        .global_remove => {},
+    }
+}
+
+fn seatListener(seat: *wl.Seat, event: wl.Seat.Event, running: *bool) void {
+    switch (event) {
+        .capabilities => |data| {
+            std.debug.print("Seat capabilities\n  Pointer {}\n  Keyboard {}\n  Touch {}\n", .{
+                data.capabilities.pointer,
+                data.capabilities.keyboard,
+                data.capabilities.touch,
+            });
+            running.* = false;
+        },
+        .name => {},
+    }
+}

--- a/src/common_core.zig
+++ b/src/common_core.zig
@@ -71,14 +71,15 @@ pub fn Dispatcher(comptime Obj: type, comptime Data: type) type {
                 if (payload_num == opcode) {
                     var payload_data: payload_field.field_type = undefined;
                     inline for (@typeInfo(payload_field.field_type).Struct.fields) |f, i| {
-                        @field(payload_data, f.name) = switch (f.field_type) {
-                            Fixed => @intToEnum(Fixed, args[i].i),
-                            else => switch (@sizeOf(f.field_type)) {
+                        if (@typeInfo(f.field_type) == .Enum) {
+                            @field(payload_data, f.name) = @intToEnum(f.field_type, args[i].i);
+                        } else {
+                            @field(payload_data, f.name) = switch (@sizeOf(f.field_type)) {
                                 4 => @bitCast(f.field_type, args[i].u),
                                 8 => @intToPtr(f.field_type, @ptrToInt(args[i].s)),
                                 else => unreachable,
-                            },
-                        };
+                            };
+                        }
                     }
 
                     @ptrCast(fn (*Obj, Payload, Data) void, implementation)(


### PR DESCRIPTION
Not sure right now how to deal with bitmasks like this:

```zig
    layer_surface.setAnchor(
        wlr.LayerSurfaceV1.Anchor.top |
            wlr.LayerSurfaceV1.Anchor.bottom |
            wlr.LayerSurfaceV1.Anchor.right |
            wlr.LayerSurfaceV1.Anchor.left,
    );
```

From what I'm reading, packed structs seems to be the generally recommended approach here? 

Looking at https://github.com/markfirmware/zig-vector-table/blob/c69f04caf843d9b7977980a5230f3ced415003dc/main.zig#L58 and https://github.com/SpexGuy/Zig-Vulkan-Headers/blob/c4fbb4cbd2e6649e0d477158ef4b348a38a2a1b9/zig/vulkan_core.zig#L24 as an example right now.

* [x] bitfields
* [x] fix cross protocol enum references, i.e. screencopy referencing `shm.Format`