### PR TITLE
ci: fix xbps invocation

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
-          xbps-install -uy zig wayland-devel wayland-protocols pkgconf git
+          xbps-install -Sy xbps
+          xbps-install -uy
+          xbps-install -y zig wayland-devel wayland-protocols pkgconf git gcc
 
       - name: checkout
         uses: actions/checkout@v2
@@ -43,10 +43,9 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
+          xbps-install -Sy xbps
           xbps-install -uy
-          xbps-install -uy zig git
+          xbps-install -y zig git
 
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This avoids errors like:

util-linux-common-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
util-linux-common-2.37.2_1 in transaction breaks installed pkg `libsmartcols-2.37.1_1'
libuuid-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
libuuid-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
libblkid-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
libblkid-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
libmount-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
Transaction aborted due to unresolved dependencies.