### PR TITLE
scanner: require explicit target globals/versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ const wl = wayland.client.wl;
 There is an example project using zig-wayland here:
 [hello-zig-wayland](https://github.com/ifreund/hello-zig-wayland).
 
+Note that zig-wayland does not currently do extensive verification of Wayland
+protocol xml or provide good error messages if protocol xml is invalid. It is
+recommend to use `wayland-scanner --strict` to debug protocol xml instead.
+
 ## License
 
 zig-wayland is released under the MIT (expat) license.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ pub fn build(b: *Builder) void {
 
     const scanner = ScanProtocolsStep.create(b);
     scanner.addSystemProtocol("stable/xdg-shell/xdg-shell.xml");
-    scanner.addProtocolPath("protocol/foobar.xml");
+    scanner.addSystemProtocol("staging/ext-session-lock/ext-session-lock-v1.xml");
+    scanner.addProtocolPath("protocol/private_foobar.xml");
+
+    // Pass the maximum version implemented by your wayland server or client.
+    // Requests, events, enums, etc. from newer versions will not be generated,
+    // ensuring forwards compatibility with newer protocol xml.
+    // This will also generate code for interfaces created using the provided
+    // global interface, in this example wl_keyboard, wl_pointer, xdg_surface,
+    // xdg_toplevel, etc. would be generated.
+    scanner.generate("wl_seat", 4);
+    scanner.generate("xdg_wm_base", 3);
+    scanner.generate("ext_session_lock_manager_v1", 1);
+    scanner.generate("private_foobar_manager", 1);
 
     const exe = b.addExecutable("foo", "foo.zig");
     exe.setTarget(target);


### PR DESCRIPTION
Now only wl_display, wl_registry, and wl_callback are generated by
default (these interfaces are locked to version 1 for eternity).

All other interfaces must be explicitly requested in the program's
build.zig using ScanProtocolsStep.generate(global_name, version).

This ensures forwards compatibility of programs written using
zig-wayland with newer protocol xml.

Closes #14