### PR TITLE
use `std.testing.refAllDeclsRecursive` instead of local implementation

### DIFF
--- a/src/ref_all.zig
+++ b/src/ref_all.zig
@@ -1,21 +1,5 @@
-// Note: this requires the fix made in https://github.com/ziglang/zig/pull/7178
-// to work properly with zig-wayland's use of usingnamespace
-fn refAllDeclsRecursive(comptime T: type) void {
-    const decls = switch (@typeInfo(T)) {
-        .Struct => |info| info.decls,
-        .Union => |info| info.decls,
-        .Enum => |info| info.decls,
-        .Opaque => |info| info.decls,
-        else => return,
-    };
-    inline for (decls) |decl| {
-        switch (decl.data) {
-            .Type => |T2| refAllDeclsRecursive(T2),
-            else => _ = decl,
-        }
-    }
-}
+const std = @import("std");
 
-test "" {
-    refAllDeclsRecursive(@import("wayland"));
+test {
+    std.testing.refAllDeclsRecursive(@import("wayland"));
 }


### PR DESCRIPTION
Added in zig 0.10