### PR TITLE
Update to zig 0.10.0-dev.4476+0f0076666

### DIFF
--- a/src/common_core.zig
+++ b/src/common_core.zig
@@ -100,7 +100,7 @@ pub fn Dispatcher(comptime Obj: type, comptime Data: type) type {
                         }
                     }
 
-                    @ptrCast(fn (*Obj, Payload, Data) void, implementation)(
+                    @ptrCast(*const fn (*Obj, Payload, Data) void, implementation)(
                         @ptrCast(*Obj, object),
                         @unionInit(Payload, payload_field.name, payload_data),
                         @intToPtr(Data, @ptrToInt(object.getUserData())),

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -695,7 +695,7 @@ const Interface = struct {
                     \\pub inline fn setHandler(
                     \\    _{[interface]}: *{[type]},
                     \\    comptime T: type,
-                    \\    handle_request: fn (_{[interface]}: *{[type]}, request: Request, data: T) void,
+                    \\    handle_request: *const fn (_{[interface]}: *{[type]}, request: Request, data: T) void,
                     \\    comptime handle_destroy: ?fn (_{[interface]}: *{[type]}, data: T) void,
                     \\    _data: T,
                     \\) void {{
@@ -1166,16 +1166,7 @@ const Enum = struct {
                 if (entry.since <= target_version) {
                     const value = entry.intValue();
                     if (value != 0 and std.math.isPowerOfTwo(value)) {
-                        try writer.print("{s}", .{entry.name});
-                        if (entries_emitted == 0) {
-                            // Align the first field to ensure the entire packed
-                            // struct matches the alignment of a u32. This allows
-                            // using the packed struct as the field of an extern
-                            // struct where a u32 is expected.
-                            try writer.writeAll(": bool align(@alignOf(u32)) = false,");
-                        } else {
-                            try writer.writeAll(": bool = false,");
-                        }
+                        try writer.print("{s}: bool = false,", .{entry.name});
                         entries_emitted += 1;
                     }
                 }
@@ -1260,7 +1251,7 @@ fn trimPrefix(s: []const u8) []const u8 {
 
 const Case = enum { title, camel };
 
-fn formatCaseImpl(case: Case, comptime trim: bool) type {
+fn formatCaseImpl(comptime case: Case, comptime trim: bool) type {
     return struct {
         pub fn f(
             bytes: []const u8,

--- a/src/wayland_client_core.zig
+++ b/src/wayland_client_core.zig
@@ -54,7 +54,7 @@ pub const Proxy = opaque {
             error.OutOfMemory;
     }
 
-    const DispatcherFn = fn (
+    const DispatcherFn = *const fn (
         implementation: ?*const anyopaque,
         proxy: *Proxy,
         opcode: u32,


### PR DESCRIPTION
Based on #37 

I removed the `align(@alignOf(u32))` from the first `bool` in a generated bitset. From my reading of the zig documentation, it seems that packed structs now do this by default? I haven't run any extensive tests to see if it works, other than getting a hello world running.

This PR also removes support for `stage1` at the moment, though that could be remedied by using `std.meta.FnPtr` instead of `*const fn`.