### PR TITLE
Replace deprecated and add options structure

### DIFF
--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -404,14 +404,14 @@ const Protocol = struct {
         if (protocol.copyright) |copyright| {
             var it = mem.split(u8, copyright, "\n");
             while (it.next()) |line| {
-                try writer.print("// {s}\n", .{mem.trim(u8, line, &std.ascii.spaces)});
+                try writer.print("// {s}\n", .{mem.trim(u8, line, &std.ascii.whitespace)});
             }
             try writer.writeByte('\n');
         }
         if (protocol.toplevel_description) |toplevel_description| {
             var it = mem.split(u8, toplevel_description, "\n");
             while (it.next()) |line| {
-                try writer.print("// {s}\n", .{mem.trim(u8, line, &std.ascii.spaces)});
+                try writer.print("// {s}\n", .{mem.trim(u8, line, &std.ascii.whitespace)});
             }
             try writer.writeByte('\n');
         }


### PR DESCRIPTION
This PR replaces `std.ascii.spaces` which is deprecated with `std.ascii.whitespace`. This also introduces the
`ScanProtocolsStep.Options` structure which specifies the Wayland directory and protocols directory. `addSystemProtocol` has also been aliased to `addProtocolPath` while joining the relative path to the end of the protocols directory path.

The options structure was added to make zig-wayland more flexible. It is possible to now use custom Wayland builds easily. The use of making `addSystemProtocol` work with `addProtocolPath` is to make things easier to manage.

I've noticed in #42 that zig-wayland won't be update to support Zig master but according to the [milestone](https://github.com/ziglang/zig/milestone/17), it is not too far out so replacing it now won't hurt.